### PR TITLE
fix(ci): move away from gradle/gradle-build-action, fix artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Artifacts
+          name: artifacts-${{ matrix.os }}
           path: lwjgl3/build/distributions/*.zip


### PR DESCRIPTION
ci was broke because i got distracted and didn't check it fully over before pushing the original version